### PR TITLE
[ BUGFIX ] Fix Package Syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --watchAll --verbose
+    "test": "jest --watchAll --verbose"
   },
   "dependencies": {
     "axios": "0.27.2",


### PR DESCRIPTION
## Problem

The syntax in package.json file as wrong, and this is causing the error to run deploy in vercel. This was caused by a change that was made where the value of a property in the package.json file was not closed. 

## Solution

- Replaced the value of `"test"` property to `"test": "jest --watchAll --verbose"`